### PR TITLE
Jcn 161 kms encryption package

### DIFF
--- a/lib/kms-crypto-wrapper.js
+++ b/lib/kms-crypto-wrapper.js
@@ -1,5 +1,5 @@
 'use strict';
 
-const { KmsKeyringNode, encrypt, decrypt } = require('@aws-crypto/client-node');
+const { KMS } = require('aws-sdk');
 
-module.exports = { KmsKeyringNode, encrypt, decrypt };
+module.exports = KMS;

--- a/lib/kms-crypto-wrapper.js
+++ b/lib/kms-crypto-wrapper.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { KmsKeyringNode, encrypt, decrypt } = require('@aws-crypto/client-node');
+
+module.exports = { KmsKeyringNode, encrypt, decrypt };

--- a/lib/kms-encryption-error.js
+++ b/lib/kms-encryption-error.js
@@ -4,7 +4,11 @@ class KmsEncryptionError extends Error {
 
 	static get codes() {
 
-		return {};
+		return {
+			key: 10,
+			encrypt: 20,
+			decrypt: 30
+		};
 
 	}
 

--- a/lib/kms-encryption-error.js
+++ b/lib/kms-encryption-error.js
@@ -5,7 +5,7 @@ class KmsEncryptionError extends Error {
 	static get codes() {
 
 		return {
-			key: 10,
+			arn: 10,
 			encrypt: 20,
 			decrypt: 30
 		};

--- a/lib/kms-encryption.js
+++ b/lib/kms-encryption.js
@@ -72,7 +72,7 @@ class KmsEncryption {
 			return this[`_${method}Format`](response);
 
 		} catch(err) {
-			throw new KmsEncryptionError(`Error on ${method}: ${err.message}`, KmsEncryptionError.codes[method]);
+			throw new KmsEncryptionError(`Error on ${method}: ${(err && err.message) || 'call to service'}`, KmsEncryptionError.codes[method]);
 		}
 	}
 

--- a/lib/kms-encryption.js
+++ b/lib/kms-encryption.js
@@ -1,5 +1,50 @@
 'use strict';
 
-class KmsEncryption {}
+const KmsEncryptionError = require('./kms-encryption-error');
+const KMSWrapper = require('./kms-crypto-wrapper');
+
+class KmsEncryption {
+
+	constructor(arn, alias, key) {
+		try {
+			this.keyProcess = new KMSWrapper.KmsKeyringNode({
+				generatorKeyId: `${arn}:alias/${alias}`,
+				keyIds: [`${arn}:key/${key}`]
+			});
+		} catch(err) {
+			throw new KmsEncryptionError(`Error at create KMS Key: ${err.message}`, KmsEncryptionError.codes.key);
+		}
+	}
+
+	async _process(method, value, ...params) {
+		try {
+			const { [value]: response } = await KMSWrapper[method](this.keyProcess, ...params);
+
+			if(!response)
+				throw new Error(`invalid ${value} from service`);
+
+			return this[`_${method}Format`](response);
+
+		} catch(err) {
+			throw new KmsEncryptionError(`Error on ${method}: ${err.message}`, KmsEncryptionError.codes[method]);
+		}
+	}
+
+	_encryptFormat(ciphertext) {
+		return ciphertext.toString('base64');
+	}
+
+	_decryptFormat(plaintext) {
+		return JSON.parse(plaintext.toString());
+	}
+
+	encrypt(toEncrypt) {
+		return this._process('encrypt', 'ciphertext', JSON.stringify(toEncrypt));
+	}
+
+	decrypt(toDecrypt) {
+		return this._process('decrypt', 'plaintext', toDecrypt, { encoding: 'base64' });
+	}
+}
 
 module.exports = KmsEncryption;

--- a/lib/kms-encryption.js
+++ b/lib/kms-encryption.js
@@ -5,6 +5,13 @@ const KMSWrapper = require('./kms-crypto-wrapper');
 
 class KmsEncryption {
 
+	/**
+	 * Constructs the object.
+	 *
+	 * @param {string} arn The arn create in KMS (AWS)
+	 * @param {string} alias The alias of the key created in service
+	 * @param {string} key The key of the key(KMS) created in service
+	 */
 	constructor(arn, alias, key) {
 		try {
 			this.keyProcess = new KMSWrapper.KmsKeyringNode({
@@ -16,6 +23,14 @@ class KmsEncryption {
 		}
 	}
 
+	/**
+	 * Process data with KMS package
+	 *
+	 * @param string method The method name to call in KMS
+	 * @param string value The value to obtain in Process
+	 * @param {Array} params The parameters
+	 * @return {Promise} Response formatted or error in another case
+	 */
 	async _process(method, value, ...params) {
 		try {
 			const { [value]: response } = await KMSWrapper[method](this.keyProcess, ...params);
@@ -30,18 +45,42 @@ class KmsEncryption {
 		}
 	}
 
+	/**
+	 * Format response from encrypt
+	 *
+	 * @param {string} ciphertext The ciphertext
+	 * @return {string} response formatted
+	 */
 	_encryptFormat(ciphertext) {
 		return ciphertext.toString('base64');
 	}
 
+	/**
+	 * Format response from decrypt
+	 *
+	 * @param {string} plaintext The plaintext
+	 * @return {mixed} response formatted
+	 */
 	_decryptFormat(plaintext) {
 		return JSON.parse(plaintext.toString());
 	}
 
+	/**
+	 * Encrypt data with KMS
+	 *
+	 * @param {mixed} toEncrypt To encrypt
+	 * @return {promise} data encrypted
+	 */
 	encrypt(toEncrypt) {
 		return this._process('encrypt', 'ciphertext', JSON.stringify(toEncrypt));
 	}
 
+	/**
+	 * Decrypt data encrypted with KMS
+	 *
+	 * @param {string} toDecrypt To decrypt
+	 * @return {promise} data decrypted
+	 */
 	decrypt(toDecrypt) {
 		return this._process('decrypt', 'plaintext', toDecrypt, { encoding: 'base64' });
 	}

--- a/lib/kms-encryption.js
+++ b/lib/kms-encryption.js
@@ -8,35 +8,64 @@ class KmsEncryption {
 	/**
 	 * Constructs the object.
 	 *
-	 * @param {string} arn The arn create in KMS (AWS)
-	 * @param {string} alias The alias of the key created in service
-	 * @param {string} key The key of the key(KMS) created in service
+	 * @param {Object} arg1 object with ARNs
+	 * @param {string} arg1.keyArn The arn with key created in KMS (AWS)
+	 * @param {string} arg1.aliasArn The arn with alias created in KMS (AWS)
 	 */
-	constructor(arn, alias, key) {
-		try {
-			this.keyProcess = new KMSWrapper.KmsKeyringNode({
-				generatorKeyId: `${arn}:alias/${alias}`,
-				keyIds: [`${arn}:key/${key}`]
-			});
-		} catch(err) {
-			throw new KmsEncryptionError(`Error at create KMS Key: ${err.message}`, KmsEncryptionError.codes.key);
-		}
+	constructor({ keyArn, aliasArn }) {
+		this._keyId = this._validateArn([keyArn, aliasArn]);
+		this._kms = new KMSWrapper({
+			region: this._keyId.split(':')[3]
+		});
+	}
+
+	/**
+	 * Validate a ARN from KMS
+	 *
+	 * @param {array} arns The arns
+	 * @throws Will throw an error if invalid ARNs
+	 * @return {string} valid ARN
+	 */
+	_validateArn(arns) {
+
+		const validArn = arns.find(arn => {
+			if(typeof arn !== 'string')
+				return false;
+
+			const arnSplitted = arn.split(':');
+			if(arnSplitted.length !== 6)
+				return false;
+
+			const type = arnSplitted[5].split('/');
+			if((type[0] !== 'key' && type[0] !== 'alias') || !type[1])
+				return false;
+
+			return arnSplitted[0] === 'arn'
+				&& arnSplitted[1] === 'aws'
+				&& arnSplitted[2] === 'kms'
+				&& !!arnSplitted[3]
+				&& !!arnSplitted[4];
+		});
+
+		if(validArn)
+			return validArn;
+
+		throw new KmsEncryptionError('Error at create KMS: invalid ARN', KmsEncryptionError.codes.arn);
 	}
 
 	/**
 	 * Process data with KMS package
 	 *
-	 * @param string method The method name to call in KMS
-	 * @param string value The value to obtain in Process
-	 * @param {Array} params The parameters
+	 * @param {string} method The method name to call in KMS
+	 * @param {string} value The value to obtain in Process
 	 * @return {Promise} Response formatted or error in another case
 	 */
-	async _process(method, value, ...params) {
+	async _process(method, options, propertyRes) {
 		try {
-			const { [value]: response } = await KMSWrapper[method](this.keyProcess, ...params);
+			const { [propertyRes]: response } = await this._kms[method](options).promise();
 
 			if(!response)
-				throw new Error(`invalid ${value} from service`);
+				throw new Error('invalid response from service');
 
 			return this[`_${method}Format`](response);
 
@@ -72,7 +101,10 @@ class KmsEncryption {
 	 * @return {promise} data encrypted
 	 */
 	encrypt(toEncrypt) {
-		return this._process('encrypt', 'ciphertext', JSON.stringify(toEncrypt));
+		return this._process('encrypt', {
+			KeyId: this._keyId,
+			Plaintext: Buffer.from(JSON.stringify(toEncrypt))
+		}, 'CiphertextBlob');
 	}
 
 	/**
@@ -82,7 +114,9 @@ class KmsEncryption {
 	 * @return {promise} data decrypted
 	 */
 	decrypt(toDecrypt) {
-		return this._process('decrypt', 'plaintext', toDecrypt, { encoding: 'base64' });
+		return this._process('decrypt', {
+			CiphertextBlob: Buffer.from(toDecrypt, 'base64')
+		}, 'Plaintext');
 	}
 }
 

--- a/lib/kms-encryption.js
+++ b/lib/kms-encryption.js
@@ -23,8 +23,8 @@ class KmsEncryption {
 	 * Validate a ARN from KMS
 	 *
 	 * @param {array} arns The arns
-	 * @throws Will throw an error if invalid ARNs
 	 * @return {string} valid ARN
+	 * @throws {KmsEncryptionError} Will throw an error if invalid ARNs
 	 */
 	_validateArn(arns) {
 
@@ -57,8 +57,10 @@ class KmsEncryption {
 	 * Process data with KMS package
 	 *
 	 * @param {string} method The method name to call in KMS
-	 * @param {string} value The value to obtain in Process
+	 * @param {object} options The options to include in call
+	 * @param {string} propertyRes The property expected in response from KMS
 	 * @return {Promise} Response formatted or error in another case
+	 * @throws {KmsEncryptionError} Will throw an error if received an invalid response or an error on call to KMS
 	 */
 	async _process(method, options, propertyRes) {
 		try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,160 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/cache-material": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-0.1.0-preview.3.tgz",
+      "integrity": "sha512-Z262knWJ8NaFEFW2zA9dnLCq0pnYKRTsthRyl6bChLVqUqweM4JMYLIn7avYy7lB5HhpMbvUudlL7rB0YNjhag==",
+      "requires": {
+        "@aws-crypto/material-management": "^0.2.0-preview.3",
+        "@aws-crypto/serialize": "^0.1.0-preview.3",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^5.1.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/caching-materials-manager-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-NYLgioL8ou44/qxhCHoJnsB/yTLJxLNXvefgBo7YrX0TE+GCuL5Mi5P4hPSUuyPZFBKPsqHhc4wnzjoiQuLj+w==",
+      "requires": {
+        "@aws-crypto/cache-material": "^0.1.0-preview.3",
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/client-node": {
+      "version": "0.1.0-preview.4",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-0.1.0-preview.4.tgz",
+      "integrity": "sha512-yRN5OAHP9gZjGSegydj9GKp26xRhFBS/EIgBP6IEy+KfiTVbTNPuJtideAPul3Ob1NAXrs8R8gUrA/7fB+8aSg==",
+      "requires": {
+        "@aws-crypto/caching-materials-manager-node": "^0.1.0-preview.3",
+        "@aws-crypto/decrypt-node": "^0.1.0-preview.3",
+        "@aws-crypto/encrypt-node": "^0.1.0-preview.3",
+        "@aws-crypto/kms-keyring-node": "^0.1.0-preview.3",
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "@aws-crypto/raw-aes-keyring-node": "^0.1.0-preview.3",
+        "@aws-crypto/raw-rsa-keyring-node": "^0.1.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/decrypt-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-tSmD04H8mRe8Cy8YRdn6R67KXEMvIxYJQlN3st4j10ghJIxUl027a2f5e5ABnwWWqeMyjofpklKtwNDridRTcg==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "@aws-crypto/serialize": "^0.1.0-preview.3",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.0.0",
+        "readable-stream": "^3.2.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/encrypt-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-s85Vpa4+LzsIsf48iW8XUo7+ciRkc64w3WDBPWB+j6YuzaiN+YWL84ZpRTHJZGCV7PRQoLnz7PdJipHdMqdvRQ==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "@aws-crypto/serialize": "^0.1.0-preview.3",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.0.0",
+        "readable-stream": "^3.2.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/hkdf-node": {
+      "version": "0.2.0-preview.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-0.2.0-preview.1.tgz",
+      "integrity": "sha512-PnHmT7Rnh/choum9YvmZiciIyMi3hoeJ6E7fXPC9t9NY2YBYcHdhPY+K88iZ+dcW1Oo/GLb8fdDmRMkpgjYCZA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/kms-keyring": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-0.1.0-preview.3.tgz",
+      "integrity": "sha512-K4eYIT34t6ZTa3pD4LTMrpYzEGxWxDiybDu4xwghI+Ewc3OmS05CQ3u+IKgorcN4D259JYDnNPdvfZ0jpE8UlQ==",
+      "requires": {
+        "@aws-crypto/material-management": "^0.2.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/kms-keyring-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-hASrCFYnRRKdH5Q824OfIQnQ0f2NV+66buq2aAcA1jRupQt/O4/MtLdms/sEjXSWsKt+Q1icTjmsARnbNd5oXQ==",
+      "requires": {
+        "@aws-crypto/kms-keyring": "^0.1.0-preview.3",
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "aws-sdk": "^2.443.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/material-management": {
+      "version": "0.2.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-0.2.0-preview.3.tgz",
+      "integrity": "sha512-QLqtRPP6qsLrehONuuNgW+qXeT35uHeYaWKkhVnxrITgh2L4ldpy8htIlA2l2eYqbbn5scFcyjiBYuddKVjBdQ==",
+      "requires": {
+        "asn1.js": "^5.0.1",
+        "bn.js": "^4.11.8",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/material-management-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-lYBdLVFhyUdAKcJnRe3/xfxA/1hCZU6MeGiuf1W9TPa3XagIergix6kaieiWd0FWcW0PdWcX5dY92DiE1MY1tA==",
+      "requires": {
+        "@aws-crypto/hkdf-node": "^0.2.0-preview.1",
+        "@aws-crypto/material-management": "^0.2.0-preview.3",
+        "@aws-crypto/serialize": "^0.1.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/raw-aes-keyring-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-YYBFS8cxQvaq6saEYGKNkRpx2FErQNX7+BUBezycYUbVknITRAH5+L8eOem4RQZfRFShLk7Bk1mXmYGGVn6NaQ==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "@aws-crypto/raw-keyring": "^0.1.0-preview.3",
+        "@aws-crypto/serialize": "^0.1.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/raw-keyring": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-0.1.0-preview.3.tgz",
+      "integrity": "sha512-taWoWmjp2yikeb2VC48i0ITY85JnrybN+SOp483uzgXRINliyv+X4OIWVBxZZA/+9DA+ssrNqFDhgGMl5oB/jw==",
+      "requires": {
+        "@aws-crypto/material-management": "^0.2.0-preview.3",
+        "@aws-crypto/serialize": "^0.1.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/raw-rsa-keyring-node": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-0.1.0-preview.3.tgz",
+      "integrity": "sha512-y+xqgSFHZFliHDLDx8aRhN1fiOrYCAOvNOwisdjQ81qCSjBSuZesyCl79ADPJVPAti6vVdoxtoArotxZT6YnLw==",
+      "requires": {
+        "@aws-crypto/material-management-node": "^0.1.0-preview.3",
+        "@aws-crypto/raw-keyring": "^0.1.0-preview.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@aws-crypto/serialize": {
+      "version": "0.1.0-preview.3",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-0.1.0-preview.3.tgz",
+      "integrity": "sha512-UrD8HVkobQ8NtcGqXmE6B1UkvobYYihK6TflsnrYd7VdkvZUmEqS8n8L0LBAtCOwStPDAsHf6UEij9RNrDuhkg==",
+      "requires": {
+        "@aws-crypto/material-management": "^0.2.0-preview.3",
+        "asn1.js": "^5.0.1",
+        "bn.js": "^4.11.8",
+        "tslib": "^1.9.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -147,6 +301,24 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
+    },
+    "@types/node": {
+      "version": "12.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -223,17 +395,53 @@
         "es-abstract": "^1.7.0"
       }
     },
+    "asn1.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
+      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.531.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.531.0.tgz",
+      "integrity": "sha512-suHIJZvDhy0YmU3dZL9Xf0NBTTokLDtW+7EqoiB7Z6Jp41VzudwT8bRiu4VwdUdxa6NdTG9i4daAFftNPIowrg==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -250,6 +458,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -452,6 +670,17 @@
         "esutils": "^2.0.2"
       }
     },
+    "duplexify": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -462,7 +691,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -737,6 +965,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
       "version": "1.0.0",
@@ -1065,6 +1298,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1100,8 +1338,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "6.5.2",
@@ -1213,8 +1450,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1250,6 +1486,11 @@
           "dev": true
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1347,11 +1588,24 @@
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2580,7 +2834,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2770,6 +3023,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2789,6 +3047,16 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "regexpp": {
@@ -2855,11 +3123,21 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "5.7.1",
@@ -2970,6 +3248,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2998,6 +3281,14 @@
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -3112,8 +3403,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -3145,6 +3435,32 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -3173,8 +3489,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -3184,6 +3499,25 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,9 +412,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.531.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.531.0.tgz",
-      "integrity": "sha512-suHIJZvDhy0YmU3dZL9Xf0NBTTokLDtW+7EqoiB7Z6Jp41VzudwT8bRiu4VwdUdxa6NdTG9i4daAFftNPIowrg==",
+      "version": "2.532.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.532.0.tgz",
+      "integrity": "sha512-+auGlLHZlcAJaJFV6kcacLteggSdN1YsalyiXoGnLhHZTBH/s9YAwHTUftYI4ifyD3fPESr/rpdceWe1m0U2Mw==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   ],
   "directories": {
     "test": "tests"
+  },
+  "dependencies": {
+    "@aws-crypto/client-node": "0.1.0-preview.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "@aws-crypto/client-node": "0.1.0-preview.4"
+    "aws-sdk": "^2.532.0"
   }
 }

--- a/tests/kms-encryption-test.js
+++ b/tests/kms-encryption-test.js
@@ -64,7 +64,7 @@ describe('KmsEncryption', () => {
 		assert.equal(res, 'dGhpcyBpcyBhIHRlc3Q=');
 	});
 
-	it('Should error on encrypt', () => {
+	it('Should error on encrypt when received a invalid body', () => {
 		const encryptStub = sandbox.stub(this.encrypt._kms, 'encrypt');
 		encryptStub.returns({
 			promise: () => Promise.resolve({})
@@ -73,6 +73,19 @@ describe('KmsEncryption', () => {
 		assert.rejects(async () => {
 			await this.encrypt.encrypt('this is a test');
 		}, new KmsEncryptionError('Error on encrypt: invalid response from service', KmsEncryptionError.codes.encrypt));
+
+		assert(encryptStub.called);
+	});
+
+	it('Should error on encrypt when error on call to service', () => {
+		const encryptStub = sandbox.stub(this.encrypt._kms, 'encrypt');
+		encryptStub.returns({
+			promise: () => Promise.reject()
+		});
+
+		assert.rejects(async () => {
+			await this.encrypt.encrypt('this is a test');
+		}, new KmsEncryptionError('Error on encrypt: call to service', KmsEncryptionError.codes.encrypt));
 
 		assert(encryptStub.called);
 	});
@@ -91,7 +104,7 @@ describe('KmsEncryption', () => {
 		assert.equal(res, 'this is a test');
 	});
 
-	it('Should error on decrypt', () => {
+	it('Should error on decrypt when received a invalid body', () => {
 		const decryptStub = sandbox.stub(this.encrypt._kms, 'decrypt');
 		decryptStub.returns({
 			promise: () => Promise.resolve({})
@@ -99,6 +112,18 @@ describe('KmsEncryption', () => {
 		assert.rejects(async () => {
 			await this.encrypt.decrypt('dGhpcyBpcyBhIHRlc3Q=');
 		}, new KmsEncryptionError('Error on decrypt: invalid response from service', KmsEncryptionError.codes.decrypt));
+
+		assert(decryptStub.called);
+	});
+
+	it('Should error on decrypt when error on call to service', () => {
+		const decryptStub = sandbox.stub(this.encrypt._kms, 'decrypt');
+		decryptStub.returns({
+			promise: () => Promise.reject()
+		});
+		assert.rejects(async () => {
+			await this.encrypt.decrypt('dGhpcyBpcyBhIHRlc3Q=');
+		}, new KmsEncryptionError('Error on decrypt: call to service', KmsEncryptionError.codes.decrypt));
 
 		assert(decryptStub.called);
 	});

--- a/tests/kms-encryption-test.js
+++ b/tests/kms-encryption-test.js
@@ -18,27 +18,33 @@ describe('KmsEncryption', () => {
 		sandbox.restore();
 	});
 
-	it('Should error on create a instance', async () => {
+	it('Should error on create a instance when received an invalid parameter', async () => {
+		// invalid type
 		assert.throws(() => {
 			new KmsEncryption('');
 		}, KmsEncryptionError);
 
+		// empty ARNs
 		assert.throws(() => {
 			new KmsEncryption({ keyArn: '', aliasArn: '' });
 		}, KmsEncryptionError);
 
+		// invalid format ARNs
 		assert.throws(() => {
 			new KmsEncryption({ keyArn: 'arn:test:error', aliasArn: 'arn:test:error' });
 		}, KmsEncryptionError);
 
+		// invalid type(key or alias) in ARNs
 		assert.throws(() => {
 			new KmsEncryption({ keyArn: 'arn:test:error:error:invalid:test', aliasArn: 'arn:test:error:error:invalid:test' });
 		}, KmsEncryptionError);
 
+		// valid type but empty value(type value)
 		assert.throws(() => {
 			new KmsEncryption({ keyArn: 'arn:test:error:error:key:', aliasArn: 'arn:test:error:error:alias:' });
 		}, KmsEncryptionError);
 
+		// valid structure ARN but invalid content
 		assert.throws(() => {
 			new KmsEncryption({ keyArn: 'arn:test:error:error:key:test', aliasArn: 'arn:test:error:error:alias:test' });
 		}, KmsEncryptionError);

--- a/tests/kms-encryption-test.js
+++ b/tests/kms-encryption-test.js
@@ -1,3 +1,74 @@
 'use strict';
 
-describe('KmsEncryption', () => {});
+const assert = require('assert');
+
+const sandbox = require('sinon').createSandbox();
+
+const KmsEncryption = require('./../index');
+
+const KMSWrapper = require('./../lib/kms-crypto-wrapper');
+const KmsEncryptionError = require('./../lib/kms-encryption-error');
+
+describe('KmsEncryption', () => {
+
+	beforeEach(() => {
+		this.encrypt = new KmsEncryption('arn:aws:kms:us-east-1:111111111111', 'AliasForTest', 'a11a11a1-111f-1111-b111-1c11111111f1');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('Should error on create a instance', async () => {
+		assert.throws(() => {
+			new KmsEncryption('', '', '');
+		});
+	});
+
+	it('Should encrypt', async () => {
+		const encryptStub = sandbox.stub(KMSWrapper, 'encrypt');
+		encryptStub.resolves({
+			ciphertext: Buffer.from('dGhpcyBpcyBhIHRlc3Q=', 'base64')
+		});
+
+		const res = await this.encrypt.encrypt('this is a test');
+
+		assert(encryptStub.called);
+		assert.equal(res, 'dGhpcyBpcyBhIHRlc3Q=');
+	});
+
+	it('Should error on encrypt', () => {
+		const encryptStub = sandbox.stub(KMSWrapper, 'encrypt');
+		encryptStub.resolves({});
+
+		assert.rejects(async () => {
+			await this.encrypt.encrypt('this is a test');
+		}, new KmsEncryptionError('Error on encrypt: invalid ciphertext from service', KmsEncryptionError.codes.encrypt));
+
+		assert(encryptStub.called);
+	});
+
+	it('Should decrypt', async () => {
+		const decryptStub = sandbox.stub(KMSWrapper, 'decrypt');
+		decryptStub.resolves({
+			plaintext: Buffer.from(JSON.stringify('this is a test'), 'utf8')
+		});
+
+		const res = await this.encrypt.decrypt('dGhpcyBpcyBhIHRlc3Q=');
+
+		assert(decryptStub.called);
+		assert.equal(res, 'this is a test');
+	});
+
+	it('Should error on decrypt', () => {
+		const decryptStub = sandbox.stub(KMSWrapper, 'decrypt');
+		decryptStub.resolves({});
+
+		assert.rejects(async () => {
+			await this.encrypt.decrypt('dGhpcyBpcyBhIHRlc3Q=');
+		}, new KmsEncryptionError('Error on decrypt: invalid plaintext from service', KmsEncryptionError.codes.decrypt));
+
+		assert(decryptStub.called);
+	});
+
+});

--- a/tests/kms-encryption-test.js
+++ b/tests/kms-encryption-test.js
@@ -1,18 +1,17 @@
+/* eslint no-underscore-dangle: 0 */
+
 'use strict';
 
 const assert = require('assert');
-
 const sandbox = require('sinon').createSandbox();
 
 const KmsEncryption = require('./../index');
-
-const KMSWrapper = require('./../lib/kms-crypto-wrapper');
 const KmsEncryptionError = require('./../lib/kms-encryption-error');
 
 describe('KmsEncryption', () => {
 
 	beforeEach(() => {
-		this.encrypt = new KmsEncryption('arn:aws:kms:us-east-1:111111111111', 'AliasForTest', 'a11a11a1-111f-1111-b111-1c11111111f1');
+		this.encrypt = new KmsEncryption({ keyArn: 'arn:aws:kms:us-east-1:111111111111:key/a11a11a1-111f-1111-b111-1c11111111f1' });
 	});
 
 	afterEach(() => {
@@ -21,14 +20,36 @@ describe('KmsEncryption', () => {
 
 	it('Should error on create a instance', async () => {
 		assert.throws(() => {
-			new KmsEncryption('', '', '');
-		});
+			new KmsEncryption('');
+		}, KmsEncryptionError);
+
+		assert.throws(() => {
+			new KmsEncryption({ keyArn: '', aliasArn: '' });
+		}, KmsEncryptionError);
+
+		assert.throws(() => {
+			new KmsEncryption({ keyArn: 'arn:test:error', aliasArn: 'arn:test:error' });
+		}, KmsEncryptionError);
+
+		assert.throws(() => {
+			new KmsEncryption({ keyArn: 'arn:test:error:error:invalid:test', aliasArn: 'arn:test:error:error:invalid:test' });
+		}, KmsEncryptionError);
+
+		assert.throws(() => {
+			new KmsEncryption({ keyArn: 'arn:test:error:error:key:', aliasArn: 'arn:test:error:error:alias:' });
+		}, KmsEncryptionError);
+
+		assert.throws(() => {
+			new KmsEncryption({ keyArn: 'arn:test:error:error:key:test', aliasArn: 'arn:test:error:error:alias:test' });
+		}, KmsEncryptionError);
 	});
 
 	it('Should encrypt', async () => {
-		const encryptStub = sandbox.stub(KMSWrapper, 'encrypt');
-		encryptStub.resolves({
-			ciphertext: Buffer.from('dGhpcyBpcyBhIHRlc3Q=', 'base64')
+		const encryptStub = sandbox.stub(this.encrypt._kms, 'encrypt');
+		encryptStub.returns({
+			promise: () => Promise.resolve({
+				CiphertextBlob: Buffer.from('dGhpcyBpcyBhIHRlc3Q=', 'base64')
+			})
 		});
 
 		const res = await this.encrypt.encrypt('this is a test');
@@ -38,20 +59,24 @@ describe('KmsEncryption', () => {
 	});
 
 	it('Should error on encrypt', () => {
-		const encryptStub = sandbox.stub(KMSWrapper, 'encrypt');
-		encryptStub.resolves({});
+		const encryptStub = sandbox.stub(this.encrypt._kms, 'encrypt');
+		encryptStub.returns({
+			promise: () => Promise.resolve({})
+		});
 
 		assert.rejects(async () => {
 			await this.encrypt.encrypt('this is a test');
-		}, new KmsEncryptionError('Error on encrypt: invalid ciphertext from service', KmsEncryptionError.codes.encrypt));
+		}, new KmsEncryptionError('Error on encrypt: invalid response from service', KmsEncryptionError.codes.encrypt));
 
 		assert(encryptStub.called);
 	});
 
 	it('Should decrypt', async () => {
-		const decryptStub = sandbox.stub(KMSWrapper, 'decrypt');
-		decryptStub.resolves({
-			plaintext: Buffer.from(JSON.stringify('this is a test'), 'utf8')
+		const decryptStub = sandbox.stub(this.encrypt._kms, 'decrypt');
+		decryptStub.returns({
+			promise: () => Promise.resolve({
+				Plaintext: Buffer.from(JSON.stringify('this is a test'), 'utf8')
+			})
 		});
 
 		const res = await this.encrypt.decrypt('dGhpcyBpcyBhIHRlc3Q=');
@@ -61,12 +86,13 @@ describe('KmsEncryption', () => {
 	});
 
 	it('Should error on decrypt', () => {
-		const decryptStub = sandbox.stub(KMSWrapper, 'decrypt');
-		decryptStub.resolves({});
-
+		const decryptStub = sandbox.stub(this.encrypt._kms, 'decrypt');
+		decryptStub.returns({
+			promise: () => Promise.resolve({})
+		});
 		assert.rejects(async () => {
 			await this.encrypt.decrypt('dGhpcyBpcyBhIHRlc3Q=');
-		}, new KmsEncryptionError('Error on decrypt: invalid plaintext from service', KmsEncryptionError.codes.decrypt));
+		}, new KmsEncryptionError('Error on decrypt: invalid response from service', KmsEncryptionError.codes.decrypt));
 
 		assert(decryptStub.called);
 	});


### PR DESCRIPTION
Se integro con el package aws-sdk puntualmente con KMS, basicamente se simplico su uso y se da lugar a encriptar cualquier dato de forma que sea transparente para el que lo usa.
Los metodos que en fin terminan siendo utilizables son encrypt() y decrypt()

Dado caso de exito:
encrypt() va a retornar un string en base64
decrypt() devuelve lo que se encuentra encriptado en el base64 dado anteriormente por encrypt()

A tener en cuenta, el package soporta dos formatos de ARN el que pose la key y el de alias donde son el siguiente formato:
KEY: ${arn_base}:key/${key}
ALIAS: ${arn_base}:alias/${alias} 

los mismos deben llegar como propiedad en un objeto sea "keyArn" o "aliasArn", en caso de pasarse los dos y de ser los dos validos se prioriza el format key.